### PR TITLE
Tighten skill guidance and split command reference

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,801 +1,105 @@
 ---
 name: opencli-rs
-description: |
-  Use opencli-rs CLI to interact with social/content websites (HackerNews, DevTo, Lobsters, StackOverflow, Steam, Linux-do, Arxiv, Wikipedia, Apple-Podcasts, Xiaoyuzhou, BBC, Hugging Face, SinaFinance, Google, V2EX, Bloomberg, Twitter/X, Bilibili, Reddit, Zhihu, Xiaohongshu, Xueqiu, Weibo, Douban, WeRead, YouTube, Medium, Substack, SinaBlog, BOSS直聘, Jike, Facebook, Instagram, TikTok, Yollomi, Yahoo-Finance, Barchart, LinkedIn, Reuters, SMZDM, Ctrip, Coupang, Grok, Jimeng, Chaoxing, Weixin, Doubao, Cursor, Codex, ChatWise, ChatGPT, Doubao-App, Notion, Discord, Antigravity etc.) via the user's Chrome login session. ALWAYS prefer opencli-rs over playwright/browser automation for these supported sites. Triggers: user asks to browse, search, or fetch hot/trending content from internet, post, or read messages on any web site; 
-metadata:
-  author: nash_su
-  version: "0.1.0"
+description: Use the opencli-rs CLI to retrieve or act on supported websites and desktop apps through the user's existing Chrome login session or local desktop app session. Prefer this skill over generic browser automation when the user wants to browse, search, read feeds, inspect timelines, fetch trending content, or perform supported actions on sites like Hacker News, Reddit, YouTube, X/Twitter, Bloomberg, Google, Substack, Medium, LinkedIn, Yahoo Finance, Barchart, Discord desktop, Notion, Cursor, Codex, ChatGPT, and other opencli-rs-supported targets.
 ---
 
 # opencli-rs
 
-Blazing fast Rust CLI tool that turns 55+ websites into CLI interfaces, reusing Chrome's login state. Zero credentials needed. Single 4.7MB binary, zero runtime dependencies.
+Use `opencli-rs` when it is a better fit than generic browser automation:
+- The target site or desktop app is already supported by `opencli-rs`
+- The user wants structured fetch/search/read actions
+- The user wants a supported write action and the risk is acceptable
+- Reusing the user's existing Chrome login state is the point
 
-**Rule: use opencli-rs for supported sites instead of playwright or browser tools.**
+Do **not** treat this as a blanket replacement for the browser skill. If the site is unsupported, the page interaction is highly custom, or the task needs visual navigation/form work, use the browser workflow instead.
 
-## Syntax
+## Prerequisites
+
+Before relying on this skill, verify the environment:
+- `opencli-rs` is installed and on `PATH`
+- Chrome is open and already logged into the relevant site for browser-backed commands
+- The opencli-rs Chrome extension is installed when browser-backed commands are needed
+- For desktop-app commands, the relevant desktop app is running
+
+Quick checks:
 
 ```bash
-opencli-rs <site> <command> [--option value] [--format json]
-```
-** If opencli-rs is not installed or missing, you can install it with `curl -fsSL https://raw.githubusercontent.com/nashsu/opencli-rs/main/scripts/install.sh | sh`, if is in windows, ask user to install from https://github.com/nashsu/opencli-rs**
-
-
-**Common flags (all commands):**
-- `--format json` — machine-readable output (preferred for parsing)
-- `--limit N` — number of results (default varies, usually 20)
-- `--format table|json|yaml|md|csv`
-
-## Quick Examples
-
-```bash
-# 读取/浏览
-opencli-rs bilibili hot --limit 10 --format json
-opencli-rs zhihu hot --format json
-opencli-rs weibo hot --format json
-opencli-rs twitter timeline --format json
-opencli-rs hackernews top --limit 20 --format json
-opencli-rs v2ex hot --format json
-opencli-rs reddit hot --format json
-opencli-rs xiaohongshu feed --format json
-opencli-rs douban top250 --format json
-opencli-rs weread shelf --format json
-opencli-rs medium feed --format json
-
-# 搜索
-opencli-rs bilibili search --keyword "AI" --format json
-opencli-rs zhihu search --keyword "大模型" --format json
-opencli-rs twitter search "rust lang" --limit 10
-opencli-rs youtube search --query "LLM tutorial" --format json
-opencli-rs boss search --query "AI工程师" --city "上海" --format json
-opencli-rs google search "opencli-rs" --format json
-opencli-rs stackoverflow search "rust async" --format json
-
-# 互动（写操作）
-opencli-rs twitter post --text "Hello from CLI!"
-opencli-rs twitter reply --url "https://x.com/.../status/123" --text "Great post!"
-opencli-rs twitter like --url "https://x.com/.../status/123"
-opencli-rs jike create --text "Hello Jike!"
-opencli-rs xiaohongshu publish --title "标题" --content "内容"
-
-# 个人数据
-opencli-rs bilibili history --format json
-opencli-rs twitter bookmarks --format json
-opencli-rs xueqiu watchlist --format json
-opencli-rs weread highlights --format json
-opencli-rs reddit saved --format json
-
-
-# 诊断
+opencli-rs --help
+opencli-rs list
 opencli-rs doctor
 ```
 
+If `opencli-rs` is missing on Windows, tell the user to install it from:
+- `https://github.com/nashsu/opencli-rs`
 
+Do not run the repo's Unix shell installer on Windows.
 
-### ⚠️ 写操作风险提示（发帖/回复/点赞前必须告知）
+## Operating rules
 
-1. **账号安全**：自动化行为可能触发平台风控
-2. **不可撤回**：发布后立即公开
-3. **最佳实践**：执行前向用户展示将发布的内容，等待确认
+1. Prefer `--format json` whenever results will be parsed or summarized.
+2. Keep requests bounded with `--limit` where supported.
+3. For write actions, show the exact action first and get confirmation unless the user already clearly authorized that specific post/reply/like/follow/send action.
+4. If a command fails because login state or extension state is missing, explain the exact prerequisite instead of guessing.
+5. If `opencli-rs` does not support the target well, switch to the browser skill rather than forcing a brittle workaround.
 
- 
-## Requirements
+## Common command patterns
 
-- Chrome browser open with target site logged in
-- opencli-rs Chrome extension installed (for browser commands)
+If you need quick examples for common targets, read `references/command-subsets.md`.
 
-**核心原则：永远不说"不支持"，先尝试 opencli-rs，失败或无命令时选择自己创建**
+General syntax:
 
-## 自迭代能力：为新网站创建 CLI
-
-**当 opencli-rs 不支持某个网站时，不要放弃——自己创建！**
-
-### 流程
-
-```
-1. opencli-rs <site> --help  →  报错？说明不支持
-2. opencli-rs generate <url>  →  尝试自动生成（成功则结束）
-3. 自动生成失败 → 手动创建 YAML：
-   a. 打开目标页面
-   b. browser_evaluate 探索 DOM 结构（找 data-test 属性、class 规律）
-   c. 确认选择器后写入 ~/.opencli-rs/adapters/<site>/top.yaml
-   d. opencli-rs <site> top --format json  →  验证输出
+```bash
+opencli-rs <site> <command> [options] [--format json]
 ```
 
-### YAML 格式（DOM 抓取模板）
+Examples:
 
-```yaml
-site: <sitename>
-name: <command>
-description: <描述>
-domain: <domain>
-strategy: public
-browser: true
-
-args:
-  limit:
-    type: int
-    default: 10
-
-pipeline:
-  - navigate: https://<url>
-  - evaluate: |
-      (async () => {
-        const limit = ${{ args.limit }};
-        // DOM 抓取逻辑
-        return results;
-      })()
-
-columns: [rank, name, ...]
+```bash
+opencli-rs hackernews top --limit 20 --format json
+opencli-rs reddit search --query "openclaw" --limit 10 --format json
+opencli-rs youtube search --query "LLM tutorial" --limit 10 --format json
+opencli-rs google search OpenClaw --limit 10 --format json
+opencli-rs twitter timeline --limit 20 --format json
+opencli-rs barchart options --symbol SPY --format json
+opencli-rs yahoo-finance quote --symbol AAPL --format json
+opencli-rs notion search --query "meeting notes" --format json
+opencli-rs cursor status --format json
 ```
 
-### 调试技巧
-
-- `browser_evaluate` 先探结构：`document.querySelector('...').innerHTML`
-- 找 `data-test` 属性最稳定，其次 class 中的语义词
-- tagline 通常是 name 的兄弟元素（`nameEl.parentElement.querySelector('span...')`）
-- 去重用 `seen = new Set()`，防止重复产品
-
-## Full Command Reference
-
-# opencli-rs Command Reference
-
-All commands support: `--format table|json|yaml|md|csv`  
-
-Run `opencli-rs --help` for the full list of all 333 commands across 55+ sites.
-
----
-
-## Public Mode (No Browser Needed)
-
-### HackerNews
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `hackernews top` | `--limit N` (default 20) | Top stories |
-| `hackernews new` | `--limit N` | Newest stories |
-| `hackernews best` | `--limit N` | Best stories |
-| `hackernews ask` | `--limit N` | Ask HN |
-| `hackernews show` | `--limit N` | Show HN |
-| `hackernews jobs` | `--limit N` | Job listings |
-| `hackernews search` | `--query <str>`, `--limit N` | Search stories |
-| `hackernews user` | `--id <username>` | User profile |
-
-### Dev.to
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `devto top` | `--limit N` | Top articles |
-| `devto tag` | `--tag <str>`, `--limit N` | Articles by tag |
-| `devto user` | `--username <str>` | User's articles |
-
-### Lobsters
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `lobsters hot` | `--limit N` | Hottest stories |
-| `lobsters newest` | `--limit N` | Newest stories |
-| `lobsters active` | `--limit N` | Most active |
-| `lobsters tag` | `--tag <str>`, `--limit N` | Stories by tag |
-
-### StackOverflow
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `stackoverflow hot` | `--limit N` | Hot questions |
-| `stackoverflow search` | `--query <str>`, `--limit N` | Search questions |
-| `stackoverflow bounties` | `--limit N` | Featured bounties |
-| `stackoverflow unanswered` | `--limit N` | Unanswered questions |
-
-### Wikipedia
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `wikipedia search` | `--query <str>`, `--limit N` | Search articles |
-| `wikipedia summary` | `--title <str>` | Article summary |
-| `wikipedia random` | `--limit N` | Random articles |
-| `wikipedia trending` | `--limit N` | Trending articles |
-
-### Arxiv
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `arxiv search` | `--query <str>`, `--limit N` | Search papers |
-| `arxiv paper` | `--id <arxiv_id>` | Paper details |
-
-### BBC
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `bbc news` | `--limit N` (default 20, max 50) | BBC news headlines (RSS) |
-
-### Steam
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `steam top-sellers` | `--limit N` | Top selling games |
-
-### Hugging Face
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `hf top` | `--limit N` | Top models/spaces |
-
-### Apple Podcasts
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `apple-podcasts search` | `--query <str>`, `--limit N` | Search podcasts |
-| `apple-podcasts episodes` | `--id <podcast_id>`, `--limit N` | Podcast episodes |
-| `apple-podcasts top` | `--limit N` | Top podcasts |
-
-### 小宇宙 (Xiaoyuzhou)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `xiaoyuzhou podcast` | `--id <podcast_id>` | Podcast details |
-| `xiaoyuzhou podcast-episodes` | `--id <podcast_id>`, `--limit N` | Episodes list |
-| `xiaoyuzhou episode` | `--id <episode_id>` | Episode details |
-
-### 新浪财经 (Sina Finance)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `sinafinance news` | `--limit N` | Financial news |
-
-### Linux.do
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `linux-do hot` | `--limit N` | Hot topics |
-| `linux-do latest` | `--limit N` | Latest topics |
-| `linux-do search` | `--query <str>`, `--limit N` | Search topics |
-| `linux-do categories` | — | List categories |
-| `linux-do category` | `--id <id>`, `--limit N` | Category topics |
-| `linux-do topic` | `--id <id>` | Topic details |
-
----
-
-## Public / Browser Mode
-
-### Google
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `google news` | `--query <str>`, `--limit N` | Google News |
-| `google search` | `--query <str>`, `--limit N` | Web search |
-| `google suggest` | `--query <str>` | Autocomplete suggestions |
-| `google trends` | `--limit N` | Trending searches |
-
-### V2EX
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `v2ex hot` | `--limit N` (default 20) | 热门话题 (no login) |
-| `v2ex latest` | `--limit N` (default 20) | 最新话题 (no login) |
-| `v2ex topic` | `--id <topic_id>` | 主题详情和回复 |
-| `v2ex node` | `--name <node>`, `--limit N` | Node topics |
-| `v2ex user` | `--username <str>` | User profile |
-| `v2ex member` | `--username <str>` | Member details |
-| `v2ex replies` | `--id <topic_id>` | Topic replies |
-| `v2ex nodes` | — | List all nodes |
-| `v2ex daily` | — | 每日签到 |
-| `v2ex me` | — | 个人资料 |
-| `v2ex notifications` | `--limit N` | 通知 |
-
-### Bloomberg
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `bloomberg main` | `--limit N` | Main page news |
-| `bloomberg markets` | `--limit N` | Markets news |
-| `bloomberg economics` | `--limit N` | Economics news |
-| `bloomberg industries` | `--limit N` | Industries news |
-| `bloomberg tech` | `--limit N` | Technology news |
-| `bloomberg politics` | `--limit N` | Politics news |
-| `bloomberg businessweek` | `--limit N` | Businessweek |
-| `bloomberg opinions` | `--limit N` | Opinion columns |
-| `bloomberg feeds` | `--limit N` | All feeds |
-| `bloomberg news` | `--query <str>`, `--limit N` | Search news |
-
----
-
-## Browser Mode (Requires Chrome + Extension)
-
-### Twitter / X
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `twitter timeline` | `--limit N` (default 20) | Home timeline |
-| `twitter trending` | `--limit N` (default 20) | Trending topics |
-| `twitter search` | `--query <str>`, `--limit N` (default 15) | Search tweets |
-| `twitter bookmarks` | `--limit N` (default 20) | Bookmarks |
-| `twitter notifications` | `--limit N` (default 20) | Notifications |
-| `twitter profile` | `--username <handle>`, `--limit N` | User's tweets |
-| `twitter followers` | `--user <handle>`, `--limit N` | Followers list |
-| `twitter following` | `--user <handle>`, `--limit N` | Following list |
-| `twitter thread` | `--url <tweet_url>` | Full thread |
-| `twitter article` | `--url <article_url>` | X article content |
-| `twitter post` | `--text <str>` | Post a tweet |
-| `twitter reply` | `--url <tweet_url>`, `--text <str>` | Reply to tweet |
-| `twitter like` | `--url <tweet_url>` | Like a tweet |
-| `twitter delete` | `--url <tweet_url>` | Delete a tweet |
-| `twitter follow` | `--username <handle>` | Follow user |
-| `twitter unfollow` | `--username <handle>` | Unfollow user |
-| `twitter bookmark` | `--url <tweet_url>` | Bookmark tweet |
-| `twitter unbookmark` | `--url <tweet_url>` | Remove bookmark |
-| `twitter download` | `--url <tweet_url>` | Download media |
-| `twitter block` | `--username <handle>` | Block user |
-| `twitter unblock` | `--username <handle>` | Unblock user |
-| `twitter hide-reply` | `--url <tweet_url>` | Hide a reply |
-| `twitter accept` | — | Accept follow requests |
-| `twitter reply-dm` | `--text <str>` | Reply to DM |
-
-### Bilibili (B站)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `bilibili hot` | `--limit N` (default 20) | B站热门视频 |
-| `bilibili search` | `--keyword <str>`, `--type video\|user`, `--page N`, `--limit N` | 搜索视频或用户 |
-| `bilibili me` | — | 当前用户资料 |
-| `bilibili favorite` | `--limit N`, `--page N` | 收藏夹 |
-| `bilibili history` | `--limit N` (default 20) | 观看历史 |
-| `bilibili feed` | `--limit N`, `--type all\|video\|article` | 动态时间线 |
-| `bilibili subtitle` | `--bvid <bvid>`, `--lang <code>` | 视频字幕 |
-| `bilibili dynamic` | `--limit N` (default 15) | 用户动态 |
-| `bilibili ranking` | `--limit N` (default 20) | 排行榜 |
-| `bilibili following` | `--uid <id>`, `--page N`, `--limit N` | 关注列表 |
-| `bilibili user-videos` | `--uid <id>`, `--limit N`, `--order pubdate\|click\|stow` | 用户投稿 |
-| `bilibili download` | `--bvid <bvid>` | 下载视频 |
-
-### Reddit
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `reddit hot` | `--subreddit <name>`, `--limit N` | Hot posts |
-| `reddit frontpage` | `--limit N` (default 15) | r/all |
-| `reddit popular` | `--limit N` | Popular posts |
-| `reddit search` | `--query <str>`, `--limit N` | Search posts |
-| `reddit subreddit` | `--name <sub>`, `--sort hot\|new\|top\|rising`, `--limit N` | Subreddit posts |
-| `reddit read` | `--url <post_url>` | Read post + comments |
-| `reddit user` | `--username <str>` | User profile |
-| `reddit user-posts` | `--username <str>`, `--limit N` | User's posts |
-| `reddit user-comments` | `--username <str>`, `--limit N` | User's comments |
-| `reddit upvote` | `--url <post_url>` | Upvote post |
-| `reddit save` | `--url <post_url>` | Save post |
-| `reddit comment` | `--url <post_url>`, `--text <str>` | Comment on post |
-| `reddit subscribe` | `--subreddit <name>` | Subscribe |
-| `reddit saved` | `--limit N` | Saved posts |
-| `reddit upvoted` | `--limit N` | Upvoted posts |
-
-### 知乎 (Zhihu)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `zhihu hot` | `--limit N` (default 20) | 知乎热榜 |
-| `zhihu search` | `--keyword <str>`, `--limit N` (default 10) | 搜索内容 |
-| `zhihu question` | `--id <question_id>`, `--limit N` | 问题详情和回答 |
-| `zhihu download` | `--url <zhihu_url>` | 下载内容 |
-
-### 小红书 (Xiaohongshu)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `xiaohongshu search` | `--keyword <str>`, `--limit N` (default 20) | 搜索笔记 |
-| `xiaohongshu notifications` | `--type mentions\|likes\|connections`, `--limit N` | 通知 |
-| `xiaohongshu feed` | `--limit N` (default 20) | 首页推荐 |
-| `xiaohongshu user` | `--id <user_id>`, `--limit N` | 用户笔记 |
-| `xiaohongshu download` | `--url <note_url>` | 下载笔记 |
-| `xiaohongshu publish` | `--title <str>`, `--content <str>` | 发布笔记 |
-| `xiaohongshu creator-notes` | `--limit N` | 创作者笔记列表 |
-| `xiaohongshu creator-note-detail` | `--id <note_id>` | 创作者笔记详情 |
-| `xiaohongshu creator-notes-summary` | — | 创作者笔记汇总 |
-| `xiaohongshu creator-profile` | — | 创作者主页 |
-| `xiaohongshu creator-stats` | — | 创作者数据 |
-
-### 雪球 (Xueqiu)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `xueqiu feed` | `--page N`, `--limit N` (default 20) | 关注动态 |
-| `xueqiu hot-stock` | `--limit N` (default 20, max 50), `--type 10\|12` | 热门股票榜 |
-| `xueqiu hot` | `--limit N` (default 20) | 热门动态 |
-| `xueqiu search` | `--query <str>`, `--limit N` (default 10) | 搜索股票 |
-| `xueqiu stock` | `--symbol <code>` (如 SH600519, AAPL) | 实时行情 |
-| `xueqiu watchlist` | `--category 1\|2\|3`, `--limit N` | 自选股 |
-| `xueqiu earnings-date` | `--symbol <code>` | 财报日期 |
-
-### 微博 (Weibo)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `weibo hot` | `--limit N` (default 30, max 50) | 微博热搜 |
-| `weibo search` | `--keyword <str>`, `--limit N` | 搜索微博 |
-
-### 豆瓣 (Douban)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `douban search` | `--keyword <str>`, `--limit N` | 搜索 |
-| `douban top250` | `--limit N` | 电影 Top 250 |
-| `douban subject` | `--id <subject_id>` | 条目详情 |
-| `douban marks` | `--type movie\|book`, `--limit N` | 我的标记 |
-| `douban reviews` | `--id <subject_id>`, `--limit N` | 短评 |
-| `douban movie-hot` | `--limit N` | 热门电影 |
-| `douban book-hot` | `--limit N` | 热门图书 |
-
-### 微信读书 (WeRead)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `weread shelf` | — | 书架 |
-| `weread search` | `--keyword <str>`, `--limit N` | 搜索图书 |
-| `weread book` | `--id <book_id>` | 图书详情 |
-| `weread highlights` | `--id <book_id>` | 划线笔记 |
-| `weread notes` | `--id <book_id>` | 想法笔记 |
-| `weread notebooks` | `--limit N` | 笔记本列表 |
-| `weread ranking` | `--limit N` | 排行榜 |
-
-### YouTube
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `youtube search` | `--query <str>`, `--limit N` (default 20, max 50) | 搜索视频 |
-| `youtube video` | `--id <video_id>` | 视频详情 |
-| `youtube transcript` | `--id <video_id>`, `--lang <code>` | 视频字幕 |
-
-### BOSS直聘
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `boss search` | `--query <str>`, `--city <城市>`, `--experience <经验>`, `--degree <学历>`, `--salary <薪资>`, `--limit N` | 搜索职位 |
-| `boss detail` | `--id <job_id>` | 职位详情 |
-| `boss recommend` | `--limit N` | 推荐职位 |
-| `boss joblist` | `--limit N` | 职位列表 |
-| `boss greet` | `--id <job_id>` | 打招呼 |
-| `boss batchgreet` | `--ids <id1,id2,...>` | 批量打招呼 |
-| `boss send` | `--id <chat_id>`, `--text <str>` | 发消息 |
-| `boss chatlist` | `--limit N` | 聊天列表 |
-| `boss chatmsg` | `--id <chat_id>`, `--limit N` | 聊天记录 |
-| `boss invite` | `--id <job_id>` | 邀请面试 |
-| `boss mark` | `--id <chat_id>`, `--label <str>` | 标记 |
-| `boss exchange` | `--id <chat_id>` | 交换联系方式 |
-| `boss resume` | — | 我的简历 |
-| `boss stats` | — | 求职统计 |
-
-### Facebook
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `facebook feed` | `--limit N` | News feed |
-| `facebook profile` | `--username <str>` | User profile |
-| `facebook search` | `--query <str>`, `--limit N` | Search |
-| `facebook friends` | `--limit N` | Friends list |
-| `facebook groups` | `--limit N` | Groups |
-| `facebook events` | `--limit N` | Events |
-| `facebook notifications` | `--limit N` | Notifications |
-| `facebook memories` | — | Memories |
-| `facebook add-friend` | `--username <str>` | Add friend |
-| `facebook join-group` | `--id <group_id>` | Join group |
-
-### Instagram
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `instagram explore` | `--limit N` | Explore page |
-| `instagram profile` | `--username <str>` | User profile |
-| `instagram search` | `--query <str>`, `--limit N` | Search |
-| `instagram user` | `--username <str>`, `--limit N` | User posts |
-| `instagram followers` | `--username <str>`, `--limit N` | Followers |
-| `instagram following` | `--username <str>`, `--limit N` | Following |
-| `instagram follow` | `--username <str>` | Follow user |
-| `instagram unfollow` | `--username <str>` | Unfollow user |
-| `instagram like` | `--url <post_url>` | Like post |
-| `instagram unlike` | `--url <post_url>` | Unlike post |
-| `instagram comment` | `--url <post_url>`, `--text <str>` | Comment |
-| `instagram save` | `--url <post_url>` | Save post |
-| `instagram unsave` | `--url <post_url>` | Unsave post |
-| `instagram saved` | `--limit N` | Saved posts |
-
-### TikTok
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `tiktok explore` | `--limit N` | Explore page |
-| `tiktok search` | `--query <str>`, `--limit N` | Search |
-| `tiktok profile` | `--username <str>` | User profile |
-| `tiktok user` | `--username <str>`, `--limit N` | User videos |
-| `tiktok following` | `--limit N` | Following list |
-| `tiktok follow` | `--username <str>` | Follow user |
-| `tiktok unfollow` | `--username <str>` | Unfollow user |
-| `tiktok like` | `--url <video_url>` | Like video |
-| `tiktok unlike` | `--url <video_url>` | Unlike video |
-| `tiktok comment` | `--url <video_url>`, `--text <str>` | Comment |
-| `tiktok save` | `--url <video_url>` | Save video |
-| `tiktok unsave` | `--url <video_url>` | Unsave video |
-| `tiktok live` | `--username <str>` | Live stream |
-| `tiktok notifications` | `--limit N` | Notifications |
-| `tiktok friends` | `--limit N` | Friends |
-
-### 即刻 (Jike)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `jike feed` | `--limit N` | 动态 Feed |
-| `jike search` | `--query <str>`, `--limit N` | 搜索 |
-| `jike create` | `--text <str>` | 发动态 |
-| `jike like` | `--id <post_id>` | 点赞 |
-| `jike comment` | `--id <post_id>`, `--text <str>` | 评论 |
-| `jike repost` | `--id <post_id>`, `--text <str>` | 转发 |
-| `jike notifications` | `--limit N` | 通知 |
-| `jike post` | `--id <post_id>` | 帖子详情 |
-| `jike topic` | `--id <topic_id>`, `--limit N` | 圈子 |
-| `jike user` | `--username <str>` | 用户主页 |
-
-### Medium
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `medium feed` | `--limit N` | Feed |
-| `medium search` | `--query <str>`, `--limit N` | Search articles |
-| `medium user` | `--username <str>` | User articles |
-
-### Substack
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `substack feed` | `--limit N` | Feed |
-| `substack search` | `--query <str>`, `--limit N` | Search |
-| `substack publication` | `--name <str>`, `--limit N` | Publication posts |
-
-### 新浪博客 (Sina Blog)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `sinablog hot` | `--limit N` | 热门文章 |
-| `sinablog search` | `--query <str>`, `--limit N` | 搜索 |
-| `sinablog article` | `--url <article_url>` | 文章详情 |
-| `sinablog user` | `--id <user_id>` | 用户文章 |
-
-### 携程 (Ctrip)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `ctrip search` | `--query <str>`, `--limit N` (default 15) | 搜索城市或景点 |
-
-### 路透社 (Reuters)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `reuters search` | `--query <str>`, `--limit N` (default 10, max 40) | 搜索新闻 |
-
-### 什么值得买 (smzdm)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `smzdm search` | `--keyword <str>`, `--limit N` (default 20) | 搜索好价商品 |
-
-### LinkedIn
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `linkedin search` | `--query <str>`, `--limit N` | Search |
-
-### Yahoo Finance
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `yahoo-finance quote` | `--symbol <ticker>` (如 AAPL, MSFT, TSLA) | 股票行情 |
-
-### Barchart
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `barchart quote` | `--symbol <ticker>` | Quote |
-| `barchart options` | `--symbol <ticker>` | Options chain |
-| `barchart greeks` | `--symbol <ticker>` | Options greeks |
-| `barchart flow` | `--limit N` | Options flow |
-
-### Grok
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `grok ask` | `--text <str>` | Ask Grok |
-
-### 即梦 (Jimeng)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `jimeng generate` | `--prompt <str>` | Generate image |
-| `jimeng history` | `--limit N` | Generation history |
-
-### 超星 (Chaoxing)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `chaoxing assignments` | — | Assignments |
-| `chaoxing exams` | — | Exams |
-
-### 微信 (Weixin)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `weixin download` | `--url <article_url>` | Download article |
-
-### 豆包 (Doubao)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `doubao status` | — | Status |
-| `doubao new` | — | New conversation |
-| `doubao send` | `--text <str>` | Send message |
-| `doubao read` | — | Read response |
-| `doubao ask` | `--text <str>` | Ask question |
-
-### 拼多多海外 (Coupang)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `coupang search` | `--query <str>`, `--limit N` | Search products |
-| `coupang add-to-cart` | `--id <product_id>` | Add to cart |
-
-### Yollomi
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `yollomi generate` | `--prompt <str>` | Generate image |
-| `yollomi video` | `--prompt <str>` | Generate video |
-| `yollomi edit` | `--image <path>`, `--prompt <str>` | Edit image |
-| `yollomi upload` | `--file <path>` | Upload file |
-| `yollomi models` | — | List models |
-| `yollomi remove-bg` | `--image <path>` | Remove background |
-| `yollomi upscale` | `--image <path>` | Upscale image |
-| `yollomi face-swap` | `--source <path>`, `--target <path>` | Face swap |
-| `yollomi restore` | `--image <path>` | Restore image |
-| `yollomi try-on` | `--person <path>`, `--garment <path>` | Virtual try-on |
-| `yollomi background` | `--image <path>`, `--prompt <str>` | Change background |
-| `yollomi object-remover` | `--image <path>` | Remove object |
-
----
-
-## Desktop Mode (Requires Desktop App Running)
-
-### Cursor
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `cursor status` | — | IDE status |
-| `cursor send` | `--text <str>` | Send to Cursor |
-| `cursor read` | — | Read response |
-| `cursor new` | — | New conversation |
-| `cursor dump` | — | Dump conversation |
-| `cursor composer` | — | Open composer |
-| `cursor model` | `--name <str>` | Switch model |
-| `cursor extract-code` | — | Extract code blocks |
-| `cursor ask` | `--text <str>` | Ask question |
-| `cursor screenshot` | — | Take screenshot |
-| `cursor history` | `--limit N` | Conversation history |
-| `cursor export` | — | Export conversation |
-
-### Codex
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `codex status` | — | Status |
-| `codex send` | `--text <str>` | Send message |
-| `codex read` | — | Read response |
-| `codex new` | — | New conversation |
-| `codex dump` | — | Dump conversation |
-| `codex extract-diff` | — | Extract diffs |
-| `codex model` | `--name <str>` | Switch model |
-| `codex ask` | `--text <str>` | Ask question |
-| `codex screenshot` | — | Take screenshot |
-| `codex history` | `--limit N` | History |
-| `codex export` | — | Export |
-
-### Notion
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `notion status` | — | App status |
-| `notion search` | `--query <str>` | Search pages |
-| `notion read` | `--id <page_id>` | Read page |
-| `notion new` | `--title <str>` | New page |
-| `notion write` | `--id <page_id>`, `--content <str>` | Write to page |
-| `notion sidebar` | — | Sidebar contents |
-| `notion favorites` | — | Favorites |
-| `notion export` | `--id <page_id>` | Export page |
-
-### ChatGPT
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `chatgpt status` | — | App status |
-| `chatgpt new` | — | New conversation |
-| `chatgpt send` | `--text <str>` | Send message |
-| `chatgpt read` | — | Read response |
-| `chatgpt ask` | `--text <str>` | Ask question |
-
-### Discord
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `discord-app status` | — | App status |
-| `discord-app send` | `--channel <id>`, `--text <str>` | Send message |
-| `discord-app read` | `--channel <id>`, `--limit N` | Read messages |
-| `discord-app channels` | `--server <id>` | List channels |
-| `discord-app servers` | — | List servers |
-| `discord-app search` | `--query <str>` | Search |
-| `discord-app members` | `--server <id>` | List members |
-
-### ChatWise
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `chatwise status` | — | Status |
-| `chatwise new` | — | New conversation |
-| `chatwise send` | `--text <str>` | Send message |
-| `chatwise read` | — | Read response |
-| `chatwise ask` | `--text <str>` | Ask question |
-| `chatwise model` | `--name <str>` | Switch model |
-| `chatwise history` | `--limit N` | History |
-| `chatwise export` | — | Export |
-| `chatwise screenshot` | — | Screenshot |
-
-### 豆包 App (Doubao App)
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `doubao-app status` | — | Status |
-| `doubao-app new` | — | New conversation |
-| `doubao-app send` | `--text <str>` | Send message |
-| `doubao-app read` | — | Read response |
-| `doubao-app ask` | `--text <str>` | Ask question |
-| `doubao-app screenshot` | — | Screenshot |
-| `doubao-app dump` | — | Dump conversation |
-
-### Antigravity
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `antigravity status` | — | Status |
-| `antigravity send` | `--text <str>` | Send message |
-| `antigravity read` | — | Read response |
-| `antigravity new` | — | New conversation |
-| `antigravity dump` | — | Dump conversation |
-| `antigravity extract-code` | — | Extract code |
-| `antigravity model` | `--name <str>` | Switch model |
-| `antigravity watch` | — | Watch mode |
-
----
-
-## External CLI Integration (Passthrough)
-
-| Command | Description |
-|---------|-------------|
-| `opencli-rs gh <args>` | GitHub CLI passthrough |
-| `opencli-rs docker <args>` | Docker CLI passthrough |
-| `opencli-rs kubectl <args>` | Kubernetes CLI passthrough |
-| `opencli-rs obsidian <args>` | Obsidian passthrough |
-| `opencli-rs readwise <args>` | Readwise passthrough |
-| `opencli-rs gws <args>` | Google Workspace passthrough |
-
----
-
-## AI Discovery Commands
-
-| Command | Args | Description |
-|---------|------|-------------|
-| `opencli-rs explore` | `<url>` | Explore website APIs |
-| `opencli-rs cascade` | `<url>` | Auto-detect auth strategies |
-| `opencli-rs generate` | `<url>`, `--goal <str>` | Auto-generate adapter |
-
----
-
-## Utility Commands
-
-| Command | Description |
-|---------|-------------|
-| `opencli-rs doctor` | Run diagnostics |
-| `opencli-rs completion bash\|zsh\|fish` | Generate shell completions |
-| `opencli-rs list` | List all available commands |
+## Supported-use guidance
+
+Typical good fits:
+- News/feed/trending pulls from supported sites
+- Search across supported sites
+- Reading saved/bookmarked/history content where supported
+- Pulling quotes/options chains from supported finance targets
+- Interacting with supported desktop apps through their existing local session
+
+Higher-risk actions that need confirmation unless already explicitly authorized:
+- posting
+- replying
+- liking/upvoting
+- following/unfollowing
+- commenting
+- sending desktop-app messages
+- deleting content
+
+## Failure handling
+
+If a command errors:
+1. Re-run with a smaller scope if appropriate.
+2. Check `opencli-rs doctor`.
+3. Verify Chrome/app/login/extension prerequisites.
+4. If the target is unsupported or the flow is too custom, switch to the browser skill.
+
+## Notes
+
+- This skill complements, not replaces, browser automation.
+- Prefer native platform tools when they already cover the task better.
+- Use `opencli-rs` mainly when the value is access via the user's authenticated local browser/app session.
+
+## Source
+
+Based on:
+- Skill repo: `https://github.com/nashsu/opencli-rs-skill`
+- Upstream CLI: `https://github.com/nashsu/opencli-rs`

--- a/references/command-subsets.md
+++ b/references/command-subsets.md
@@ -1,0 +1,68 @@
+# opencli-rs command subsets
+
+Use this file only when you need quick command examples for common targets. Keep `SKILL.md` lean.
+
+## Safe public commands
+
+These are the best first tests because they do not require the browser extension or login reuse.
+
+```bash
+opencli-rs hackernews top --limit 10 --format json
+opencli-rs hackernews search --query "OpenClaw" --limit 10 --format json
+opencli-rs bbc news --limit 10 --format json
+opencli-rs arxiv search --query "large language models" --limit 10 --format json
+opencli-rs stackoverflow search --query "rust async" --limit 10 --format json
+opencli-rs devto top --limit 10 --format json
+opencli-rs lobsters hot --limit 10 --format json
+```
+
+## Browser-backed read commands
+
+Use these only after confirming Chrome is open, the user is logged in, and the extension/daemon are connected.
+
+```bash
+opencli-rs twitter timeline --limit 20 --format json
+opencli-rs twitter search "OpenClaw" --limit 10 --format json
+opencli-rs reddit frontpage --limit 15 --format json
+opencli-rs reddit search --query "OpenClaw" --limit 10 --format json
+opencli-rs youtube search --query "LLM tutorial" --limit 10 --format json
+opencli-rs bloomberg tech --limit 10 --format json
+opencli-rs yahoo-finance quote --symbol AAPL --format json
+opencli-rs barchart options --symbol SPY --format json
+opencli-rs substack feed --limit 10 --format json
+opencli-rs medium feed --limit 10 --format json
+```
+
+## Desktop-app commands
+
+Use these only if the desktop app is already running.
+
+```bash
+opencli-rs cursor status --format json
+opencli-rs codex status --format json
+opencli-rs notion search --query "meeting notes" --format json
+opencli-rs discord-app status --format json
+```
+
+## Argument gotchas
+
+Some commands take a positional argument instead of a named flag. Check `--help` for the exact form before assuming.
+
+Examples:
+
+```bash
+opencli-rs wikipedia summary OpenAI --format json
+opencli-rs google search OpenClaw --limit 3 --format json
+```
+
+Not every adapter uses `--query` or `--title`.
+
+## Diagnostics
+
+```bash
+opencli-rs --help
+opencli-rs <site> --help
+opencli-rs <site> <command> --help
+opencli-rs doctor
+opencli-rs list
+```


### PR DESCRIPTION
## Summary\n- slim down SKILL.md to keep only the triggering guidance and operating rules\n- remove nonstandard extra frontmatter and over-broad replacement claims\n- add a small reference file for curated command examples instead of embedding a giant command catalog\n\n## Why\nThe current skill works conceptually, but the raw packaging is heavier than it needs to be for an agent skill. This keeps the trigger description strong while reducing context bloat and making the skill easier to follow. It also adds guardrails around prerequisites, write-action confirmation, and fallback to browser automation when opencli-rs is not the right fit.\n\n## Notes\n- kept the core value proposition intact: use opencli-rs for supported authenticated browser/app sessions\n- intentionally did not try to duplicate the full upstream CLI docs inside SKILL.md; the CLI repo and --help already cover that well\n- tested locally on Windows: binary install succeeded, opencli-rs --help worked, public-mode hackernews top worked, and doctor correctly reported missing browser daemon/extension state when Chrome was not connected\n